### PR TITLE
Change default name of environment variable that controls the test against target

### DIFF
--- a/generator/Generator/PluginTravisYmlGenerator.php
+++ b/generator/Generator/PluginTravisYmlGenerator.php
@@ -70,7 +70,7 @@ class PluginTravisYmlGenerator extends Generator
 
         if ($this->isTargetPluginContainsPluginTests()) {
             $testsToRun[] = array('name' => 'PluginTests',
-                'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=\$PIWIK_LATEST_STABLE_TEST_TARGET");
+                'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=\$PIWIK_TEST_TARGET");
             $testsToRun[] = array('name' => 'PluginTests',
                 'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik");
 
@@ -81,11 +81,11 @@ class PluginTravisYmlGenerator extends Generator
 
         if ($this->isTargetPluginContainsUITests()) {
             $testsToRun[] = array('name' => 'UITests',
-                'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=\$PIWIK_LATEST_STABLE_TEST_TARGET");
+                'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=\$PIWIK_TEST_TARGET");
 
             $testsToExclude[] = array('description' => 'execute UI tests only w/ PHP 5.6',
                 'php' => '5.3.3',
-                'env' => "TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=\$PIWIK_LATEST_STABLE_TEST_TARGET");
+                'env' => "TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=\$PIWIK_TEST_TARGET");
         }
 
         if (empty($testsToRun)) {

--- a/generator/templates/travis.yml.twig
+++ b/generator/templates/travis.yml.twig
@@ -34,7 +34,9 @@ env:
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR
 {% else %}
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
-    - PIWIK_LATEST_STABLE_TEST_TARGET={{ latestStableVersion }}
+    # this variable controls the version of Piwik your tests will run against. increment it when
+    # making your plugin compatible with the new version of Piwik.
+    - PIWIK_TEST_TARGET={{ latestStableVersion }}
 {% endif %}
 {% if extraGlobalEnvVars|default is not empty %}{% for var in extraGlobalEnvVars %}    - {{ var|raw }}
 {% endfor %}{% endif %}

--- a/generator/tests/Integration/TravisYmlViewTest.php
+++ b/generator/tests/Integration/TravisYmlViewTest.php
@@ -50,7 +50,7 @@ class TravisYmlViewTest extends PHPUnit_Framework_TestCase
 
         $this->assertBuildSectionsNotEmpty($yaml);
 
-        $this->assertContains("export GENERATE_TRAVIS_YML_COMMAND=\"./console generate:travis-yml \\'arg1\\' arg2\"", $yaml['before_script']);
+        $this->assertContains("export GENERATE_TRAVIS_YML_COMMAND=\"./console generate:travis-yml \\'arg1\\' arg2\"", $yaml['install']);
 
         $this->assertViewUsesPluginSpecifiedTravisCommands($yaml);
     }


### PR DESCRIPTION
Changed from PIWIK_LATEST_STABLE_TEST_TARGET to PIWIK_TEST_TARGET. Added a comment to the .travis.yml instructing users when to change it.