### PR TITLE
Autodetect minimum php version of plugins by checking plugin.json.

### DIFF
--- a/generator/Generator/PluginTravisYmlGenerator.php
+++ b/generator/Generator/PluginTravisYmlGenerator.php
@@ -178,6 +178,7 @@ class PluginTravisYmlGenerator extends Generator
         $phpRequirement = $pluginJsonContents['require']['php'];
         if (!preg_match('/>=([0-9]+\.[0-9]+\.[0-9]+)/', $phpRequirement, $matches)) {
             $this->log("info", "Cannot detect minimum php version from php requirement: '$phpRequirement'");
+            return null;
         }
 
         $phpRequirement = $matches[1];

--- a/generator/Generator/PluginTravisYmlGenerator.php
+++ b/generator/Generator/PluginTravisYmlGenerator.php
@@ -24,6 +24,14 @@ class PluginTravisYmlGenerator extends Generator
         parent::__construct($options, $output);
 
         $this->targetPlugin = $targetPlugin;
+
+        if (empty($this->minimumPhpVersion)) {
+            $this->minimumPhpVersion = $this->getPluginMinimumPhpVersion();
+
+            if (!empty($this->minimumPhpVersion)) {
+                $this->replaceMinimumPhpVersionInPhpVersions();
+            }
+        }
     }
 
     protected function travisEncrypt($data)
@@ -75,7 +83,7 @@ class PluginTravisYmlGenerator extends Generator
                 'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik");
 
             $testsToExclude[] = array('description' => 'execute latest stable tests only w/ PHP 5.5',
-                'php' => '5.3.3',
+                'php' => $this->minimumPhpVersion,
                 'env' => 'TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik');
         }
 
@@ -84,7 +92,7 @@ class PluginTravisYmlGenerator extends Generator
                 'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=\$PIWIK_TEST_TARGET");
 
             $testsToExclude[] = array('description' => 'execute UI tests only w/ PHP 5.6',
-                'php' => '5.3.3',
+                'php' => $this->minimumPhpVersion,
                 'env' => "TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=\$PIWIK_TEST_TARGET");
         }
 
@@ -150,5 +158,48 @@ class PluginTravisYmlGenerator extends Generator
         $latestStable = end($tags);
         $this->log("info", "Testing against latest known stable $latestStable.");
         return $latestStable;
+    }
+
+    private function getPluginMinimumPhpVersion()
+    {
+        $pluginJsonPath = $this->getPluginJsonRootDir();
+        if (empty($pluginJsonPath)) {
+            $this->log("info", "No plugin.json file found, cannot detect minimum PHP version.");
+            return null;
+        }
+
+        $pluginJsonContents = file_get_contents($pluginJsonPath);
+        $pluginJsonContents = json_decode($pluginJsonContents, $assoc = true);
+        if (empty($pluginJsonContents['require']['php'])) {
+            $this->log("info", "No PHP version requirement in plugin.json");
+            return null;
+        }
+
+        $phpRequirement = $pluginJsonContents['require']['php'];
+        if (!preg_match('/>=([0-9]+\.[0-9]+\.[0-9]+)/', $phpRequirement, $matches)) {
+            $this->log("info", "Cannot detect minimum php version from php requirement: '$phpRequirement'");
+        }
+
+        $phpRequirement = $matches[1];
+
+        $this->log("info", "Detected minimum PHP version: '$phpRequirement'");
+
+        return $phpRequirement;
+    }
+
+    private function getPluginJsonRootDir()
+    {
+        return $this->getRepoRootDir() . '/plugin.json';
+    }
+
+    private function replaceMinimumPhpVersionInPhpVersions()
+    {
+        $phpVersions = $this->phpVersions;
+        uasort($phpVersions, 'version_compare');
+
+        reset($phpVersions);
+        $minInArrayKey = key($phpVersions);
+
+        $this->phpVersions[$minInArrayKey] = $this->minimumPhpVersion;
     }
 }

--- a/generator/templates/travis.yml.twig
+++ b/generator/templates/travis.yml.twig
@@ -15,12 +15,12 @@ language: php
 php:
   - 5.6
   - 5.3.3
-#  - hhvm
 {% else %}
 php:
 {% for version in phpVersions %}  - {{ version|raw }}
 {% endfor %}
 {% endif %}
+#  - hhvm
 
 services:
   - redis-server


### PR DESCRIPTION
As title, generate:travis-yml will now try to detect the minimum PHP version from plugin.json and if found, test against this instead of 5.3.3.

@mattab Can you do a quick review?