### PR TITLE
Allow generate:travis-yml command to force generation of travis jobs for plugin builds

### DIFF
--- a/generator/GenerateTravisYmlFile.php
+++ b/generator/GenerateTravisYmlFile.php
@@ -43,7 +43,9 @@ class GenerateTravisYmlFile extends Command
             ->addOption('php-versions', null, InputOption::VALUE_OPTIONAL,
                 "List of PHP versions to test against, ie, 5.4,5.5,5.6. Defaults to: 5.3.3,5.4,5.5,5.6.")
             ->addOption('dump', null, InputOption::VALUE_REQUIRED, "Debugging option. Saves the output .travis.yml to the specified file.")
-            ->addOption('repo-root-dir', null, InputOption::VALUE_REQUIRED, "Path to the repo for whom a .travis.yml file will be generated for.");
+            ->addOption('repo-root-dir', null, InputOption::VALUE_REQUIRED, "Path to the repo for whom a .travis.yml file will be generated for.")
+            ->addOption('force-php-tests', null, InputOption::VALUE_NONE, "Forces the presence of the PHP tests jobs for plugin builds.")
+            ->addOption('force-ui-tests', null, InputOption::VALUE_NONE, "Forces the presence of the UI tests jobs for plugin builds.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/generator/Generator/PluginTravisYmlGenerator.php
+++ b/generator/Generator/PluginTravisYmlGenerator.php
@@ -106,6 +106,10 @@ class PluginTravisYmlGenerator extends Generator
 
     private function isTargetPluginContainsPluginTests()
     {
+        if ($this->options['force-php-tests']) {
+            return true;
+        }
+
         $pluginPath = $this->getRepoRootDir();
         return $this->doesFolderContainPluginTests($pluginPath . "/tests")
         || $this->doesFolderContainPluginTests($pluginPath . "/Test");
@@ -118,6 +122,10 @@ class PluginTravisYmlGenerator extends Generator
 
     private function isTargetPluginContainsUITests()
     {
+        if ($this->options['force-ui-tests']) {
+            return true;
+        }
+
         $pluginPath = $this->getRepoRootDir();
         return $this->doesFolderContainUITests($pluginPath . "/tests")
             || $this->doesFolderContainUITests($pluginPath . "/Test");


### PR DESCRIPTION
Add force-php-tests & force-ui-tests command line options to generate:travis-yml to force generation of travis jobs for PHP/UI tests, even if the plugin has no tests present.