### PR TITLE
Add phpunit test that ensures a plugin has a certain level of quality

### DIFF
--- a/plugin_qa/PluginQualityTest.php
+++ b/plugin_qa/PluginQualityTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+/**
+ * Tests for plugin quality. All plugins maintained by Piwik or Piwik PRO must
+ * pass this test.
+ */
+class PluginQualityTest extends PHPUnit_Framework_TestCase
+{
+    private $pluginName;
+    private $pluginDir;
+
+    public function setUp()
+    {
+        $this->pluginName = getenv('PLUGIN_NAME');
+        if ($this->pluginName === false) {
+            throw new Exception("PLUGIN_NAME environment is not set, do not know which plugin to run tests against.");
+        }
+
+        $this->pluginDir = __DIR__ . '/../../../plugins/' . $this->pluginName;
+        if (!is_dir($this->pluginDir)) {
+            throw new Exception("Cannot find plugin directory at '{$this->pluginDir}'.");
+        }
+    }
+
+    public function test_Plugin_HasIntegrationSystemAndUITests()
+    {
+        // TODO: check for unit tests?
+        $testsDir = $this->getPluginTestsDirectory();
+        if (empty($testsDir)) {
+            $this->fail("Plugin has no tests.");
+        }
+
+        $phpTestTypes = array('Integration', 'System');
+        foreach ($phpTestTypes as $type) {
+            $numberOfTests = $this->getDirectoryFileCount($testsDir . '/' . $type, '/Test\.php$/');
+            $this->assertGreaterThan(0, $numberOfTests, "Plugin has 0 $type tests.");
+        }
+
+        $numberOfUITests = $this->getDirectoryFileCount($testsDir . '/UI', '/_spec\.js$/');
+        $this->assertGreaterThan(0, $numberOfUITests, "Plugin has 0 UI tests.");
+    }
+
+    private function getPluginTestsDirectory()
+    {
+        $possibleDirs = array(
+            $this->pluginDir . '/tests',
+            $this->pluginDir . '/Test',
+        );
+
+        foreach ($possibleDirs as $dir) {
+            if (is_dir($dir)) {
+                return $dir;
+            }
+        }
+
+        return null;
+    }
+
+    private function getDirectoryFileCount($directory, $regex)
+    {
+        $count = 0;
+        foreach (scandir($directory) as $file) {
+            if (preg_match($regex, $file)) {
+                ++$count;
+            }
+        }
+        return $count;
+    }
+}

--- a/plugin_qa/PluginQualityTest.php
+++ b/plugin_qa/PluginQualityTest.php
@@ -154,6 +154,26 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function test_PluginDotJsonFile_HasPluginVersion_ThatMatchesComposerDotJsonVersion()
+    {
+        $this->assertArrayHasKey($this->pluginJsonContents, "version");
+
+        $composerJsonPath = $this->pluginDir . '/composer.json';
+        if (!file_exists($composerJsonPath)) {
+            return;
+        }
+
+        $composerJsonContents = file_get_contents($composerJsonPath);
+        $composerJsonContents = json_decode($composerJsonContents, $assoc = false);
+        if (empty($composerJsonContents)) {
+            throw new Exception("composer.json file is either empty or invalid JSON");
+        }
+
+        $this->assertArrayHasKey($composerJsonContents, "version");
+        $this->assertEquals($this->pluginJsonContents["version"], $composerJsonContents["version"],
+            "Version in plugin.json does not match version in composer.json.");
+    }
+
     private function getPluginTestsDirectory()
     {
         $possibleDirs = array(

--- a/plugin_qa/PluginQualityTest.php
+++ b/plugin_qa/PluginQualityTest.php
@@ -174,6 +174,40 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
             "Version in plugin.json does not match version in composer.json.");
     }
 
+    public function test_PluginDotJsonFile_HasCorrectFields_IfPluginIsOpenSource()
+    {
+        if ($this->getRepoOwner() != "piwik") {
+            return;
+        }
+
+        $this->assertArrayHasKey("homepage", $this->pluginJsonContents);
+        $this->assertEquals("http://plugins.piwik.org/" . $this->pluginName, $this->pluginJsonContents["homepage"]);
+
+        $this->assertArrayHasKey("authors", $this->pluginJsonContents);
+        $this->assertEquals(array("name" => "Piwik", "email" => "hello@piwik.org", "homepage" => "http://piwik.org"),
+            $this->pluginJsonContents["authors"]);
+
+        $this->assertArrayHasKey("license", $this->pluginJsonContents);
+        $this->assertEquals("GPL v3+", $this->pluginJsonContents["license"]);
+    }
+
+    public function test_PluginDotJsonFile_HasCorrectFields_IfPluginIsClosedSource()
+    {
+        if ($this->getRepoOwner() != "piwikpro") {
+            return;
+        }
+
+        $this->assertArrayHasKey("homepage", $this->pluginJsonContents);
+        $this->assertEquals("https://piwik.pro/plugins", $this->pluginJsonContents["homepage"]);
+
+        $this->assertArrayHasKey("authors", $this->pluginJsonContents);
+        $this->assertEquals(array("name" => "Piwik PRO", "email" => "contact@piwik.pro", "homepage" => "https://piwik.pro"),
+            $this->pluginJsonContents["authors"]);
+
+        $this->assertArrayHasKey("license", $this->pluginJsonContents);
+        $this->assertEquals("Paid plugin", $this->pluginJsonContents["license"]);
+    }
+
     private function getPluginTestsDirectory()
     {
         $possibleDirs = array(
@@ -261,5 +295,11 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
         $repoInfo = file_get_contents($repoUrl, null, $context);
 
         return $repoInfo["description"];
+    }
+
+    private function getRepoOwner()
+    {
+        $parts = explode("/", $this->pluginSlug);
+        return $parts[0];
     }
 }

--- a/plugin_qa/PluginQualityTest.php
+++ b/plugin_qa/PluginQualityTest.php
@@ -239,6 +239,31 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function test_PluginReadme_Exists()
+    {
+        $pluginReadmePath = $this->getPluginReadmePath();
+        $this->assertFileExists($pluginReadmePath);
+    }
+
+    /**
+     * @depends test_PluginReadme_Exists
+     * @dataProvider getPluginReadmeRequiredSections
+     */
+    public function test_PluginReadme_HasRequiredSection($sectionName)
+    {
+        $pluginReadme = $this->getPluginReadme();
+        $this->assertRegExp('/\n\s*#*\s*' . preg_quote($sectionName) . '/i', $pluginReadme);
+    }
+
+    public function getPluginReadmeRequiredSections()
+    {
+        return array(
+            array('description'),
+            array('changelog'),
+            array('support'),
+        );
+    }
+
     private function getPluginTestsDirectory()
     {
         $possibleDirs = array(
@@ -368,5 +393,15 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
         if (empty($this->githubToken)) {
             throw new Exception("GITHUB_USER_TOKEN environment variable is not set, cannot run some tests.");
         }
+    }
+
+    private function getPluginReadmePath()
+    {
+        return $this->pluginDir . '/README.md';
+    }
+
+    private function getPluginReadme()
+    {
+        return file_get_contents($this->getPluginReadmePath());
     }
 }

--- a/plugin_qa/PluginQualityTest.php
+++ b/plugin_qa/PluginQualityTest.php
@@ -50,9 +50,6 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
         }
 
         $this->githubToken = getenv('GITHUB_USER_TOKEN');
-        if (empty($this->githubToken)) {
-            throw new Exception("GITHUB_USER_TOKEN environment variable is not set, cannot run some tests.");
-        }
 
         $this->pluginSlug = getenv('TRAVIS_REPO_SLUG');
         if (empty($this->pluginSlug)) {
@@ -326,7 +323,7 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
     private function getPluginRepoDescription()
     {
         $repoUrl = "https://api.github.com/repos/{$this->pluginSlug}";
-        $authHeader = "Authorization: Basic " . base64_encode(":" . $this->githubToken) . "\r\n";
+        $authHeader = "Authorization: Basic " . base64_encode(":" . $this->getGithubToken()) . "\r\n";
 
         $context = stream_context_create(array(
             'http' => array(
@@ -364,5 +361,12 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
     {
         $fileContents = file_get_contents($file);
         $this->assertStringStartsWith($expectedHeader, $fileContents);
+    }
+
+    private function getGithubToken()
+    {
+        if (empty($this->githubToken)) {
+            throw new Exception("GITHUB_USER_TOKEN environment variable is not set, cannot run some tests.");
+        }
     }
 }

--- a/plugin_qa/PluginQualityTest.php
+++ b/plugin_qa/PluginQualityTest.php
@@ -19,6 +19,7 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
 
     private $pluginName;
     private $pluginDir;
+    private $pluginFiles;
     private $pluginHasUIFiles;
     private $pluginHasNonUIFiles;
 
@@ -34,9 +35,9 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
             throw new Exception("Cannot find plugin directory at '{$this->pluginDir}'.");
         }
 
-        $pluginFiles = $this->getPluginCodeFiles();
-        $this->pluginHasUIFiles = $this->hasUIFiles($pluginFiles);
-        $this->pluginHasNonUIFiles = $this->hasNonUIFiles($pluginFiles);
+        $this->pluginFiles = $this->getPluginCodeFiles();
+        $this->pluginHasUIFiles = $this->hasUIFiles();
+        $this->pluginHasNonUIFiles = $this->hasNonUIFiles();
     }
 
     public function test_Plugin_HasIntegrationAndSystemTests_IfNonUIFilesExist()
@@ -73,6 +74,22 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
         $this->assertGreaterThan(0, $numberOfUITests, "Plugin has 0 UI tests.");
     }
 
+    public function test_Plugin_HasAtLeastOneScreenshot_IfUIFilesExist()
+    {
+        if (!$this->pluginHasUIFiles) {
+            return;
+        }
+
+        $screenshotFileCount = 0;
+        foreach ($this->pluginFiles as $file) {
+            if (preg_match('/\/screenshots\/.*\.(png|jpeg)$/', $file)) {
+                ++$screenshotFileCount;
+            }
+        }
+
+        $this->assertGreaterThan(0, $screenshotFileCount, "Plugin has UI files but no screenshots.");
+    }
+
     private function getPluginTestsDirectory()
     {
         $possibleDirs = array(
@@ -100,16 +117,6 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
         return $count;
     }
 
-    private function hasNonUIFiles($pluginFiles)
-    {
-        foreach ($pluginFiles as $file) {
-            if (!$this->isUIFile($file)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private function getPluginCodeFiles()
     {
         $result = array();
@@ -130,9 +137,19 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
         return $result;
     }
 
-    private function hasUIFiles($pluginFiles)
+    private function hasNonUIFiles()
     {
-        foreach ($pluginFiles as $file) {
+        foreach ($this->pluginFiles as $file) {
+            if (!$this->isUIFile($file)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function hasUIFiles()
+    {
+        foreach ($this->pluginFiles as $file) {
             if ($this->isUIFile($file)) {
                 return true;
             }

--- a/plugin_qa/PluginQualityTest.php
+++ b/plugin_qa/PluginQualityTest.php
@@ -102,10 +102,25 @@ class PluginQualityTest extends PHPUnit_Framework_TestCase
         $this->assertGreaterThan(0, $screenshotFileCount, "Plugin has UI files but no screenshots.");
     }
 
-    public function test_GithubRepo_HasDescriptionSet()
+    public function test_PluginDotJsonFile_HasProperFields_AndHasDescriptionMatchingGithubDesc()
     {
+        $pluginJsonPath = $this->pluginDir . '/plugin.json';
+        $this->assertTrue(file_exists($pluginJsonPath), "plugin.json does not exist");
+
+        $pluginJsonContents = file_get_contents($pluginJsonPath);
+        $pluginJsonContents = json_decode($pluginJsonContents, $assoc = true);
+        $this->assertNotEmpty($pluginJsonContents, "plugin.json is either empty or invalid JSON");
+
+        $this->assertArrayHasKey("description", $pluginJsonContents);
+
+        $pluginJsonDescription = $pluginJsonContents["description"];
+        $this->assertNotContains("TODO", $pluginJsonDescription);
+
         $repoDescription = $this->getPluginRepoDescription();
         $this->assertNotEmpty($repoDescription);
+
+        $this->assertEquals($repoDescription, $pluginJsonDescription,
+            "Plugin description in plugin.json does not match github repo description.");
     }
 
     private function getPluginTestsDirectory()

--- a/travis.sh
+++ b/travis.sh
@@ -78,6 +78,9 @@ then
     elif [ "$TEST_SUITE" = "AllTests" ]
     then
         travis_wait ./../../console tests:run --options="--colors"
+    elif [ "$TEST_SUITE" = "PluginQualityTests" ]
+    then
+        travis_wait phpunit ./../tests/plugin_qa/PluginQualityTest.php
     else
         if [ -n "$PLUGIN_NAME" ]
         then


### PR DESCRIPTION
Includes a PHPUnit test case that checks that a plugin has a certain level of quality. It is not run w/ other plugin tests, instead it should be run in a new job using phpunit directly. If creating a new job is not desired (since it may slow the build down more), we can do it in each job. The test shouldn't take too much time, so I think that's do-able as well.

Work in progress.