### PR TITLE
Automatically run tests against maximum supported piwik version

### DIFF
--- a/check_plugin_compatible_with_piwik.php
+++ b/check_plugin_compatible_with_piwik.php
@@ -7,6 +7,7 @@
  */
 
 require_once __DIR__ . '/../../core/Version.php';
+require_once __DIR__ . '/piwik_version_parser.php';
 
 $pluginName = $argv[1];
 
@@ -17,20 +18,27 @@ $pluginJsonPath = __DIR__ . "/../../../$pluginName/plugin.json";
 
 $pluginJsonContents = file_get_contents($pluginJsonPath);
 $pluginJsonContents = json_decode($pluginJsonContents, true);
-$minimumRequiredPiwik = isset($pluginJsonContents["require"]["piwik"]) ? $pluginJsonContents["require"]["piwik"] : "";
 
-if (!empty($minimumRequiredPiwik)
-    && preg_match("/^[^0-9]*(.*)/", $minimumRequiredPiwik, $matches)
-    && !empty($matches[1])
-    && version_compare(\Piwik\Version::VERSION, $matches[1]) < 0
-) {
-    echo "\n******* Plugin $pluginName's minimum required Piwik ('$minimumRequiredPiwik') is > than the test against version "
-        . \Piwik\Version::VERSION . " *******\n";
-    echo "Did you bump your plugin's minimum required Piwik to a version that doesn't exist yet? Make sure the "
-        . "PIWIK_TEST_TARGET environment variable is set to the right version, branch or commit hash in your "
-        . ".travis.yml.\n";
-    exit(1);
-} else {
-    echo "Plugin $pluginName's minimum required Piwik ('$minimumRequiredPiwik') is less than the test against version "
-        . \Piwik\Version::VERSION . "\n";
+$requiredVersions = getRequiredPiwikVersions($pluginJsonContents);
+
+foreach ($requiredVersions as $requiredVersion) {
+    $comparison = $requiredVersion['comparison'];
+    $version = $requiredVersion['version'];
+
+    if (!empty($version)
+        && preg_match("/^[^0-9]*(.*)/", $version, $matches)
+        && !empty($matches[1])
+        && version_compare(\Piwik\Version::VERSION, $matches[1]) < 0
+    ) {
+        echo "\n******* Plugin $pluginName's required Piwik ('$comparison$version') is > than the test against version "
+            . \Piwik\Version::VERSION . " *******\n";
+        echo "Did you bump your plugin's required Piwik to a version that doesn't exist yet? Make sure the "
+            . "PIWIK_TEST_TARGET environment variable is set to the right version, branch or commit hash in your "
+            . ".travis.yml.\n";
+        exit(1);
+    } else {
+        echo "Plugin $pluginName's required Piwik ('$comparison$version') is less than the test against version "
+            . \Piwik\Version::VERSION . "\n";
+    }
+
 }

--- a/checkout_test_against_branch.sh
+++ b/checkout_test_against_branch.sh
@@ -20,7 +20,15 @@ if [ "$TEST_AGAINST_PIWIK_BRANCH" == "" ]; then
 
             export TEST_AGAINST_PIWIK_BRANCH=master
         fi
-    else
+        export TEST_AGAINST_PIWIK_BRANCH=master
+    fi
+elif [[ "$TEST_AGAINST_PIWIK_BRANCH" == "maximum_supported_piwik" && "$PLUGIN_NAME" != "" ]]; then # test against the maximum supported Piwik in the plugin.json file
+    export TEST_AGAINST_PIWIK_BRANCH=$(php "$SCRIPT_DIR/get_required_piwik_version.php" $PLUGIN_NAME "max")
+
+    if ! git rev-parse "$TEST_AGAINST_PIWIK_BRANCH" >/dev/null 2>&1
+    then
+        echo "Could not find tag '$TEST_AGAINST_PIWIK_BRANCH' specified in plugin.json, testing against master."
+
         export TEST_AGAINST_PIWIK_BRANCH=master
     fi
 fi

--- a/generator/templates/travis.yml.twig
+++ b/generator/templates/travis.yml.twig
@@ -51,9 +51,12 @@ env:
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR
 {% else %}
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
-    # this variable controls the version of Piwik your tests will run against. increment it when
-    # making your plugin compatible with the new version of Piwik.
-    - PIWIK_TEST_TARGET={{ latestStableVersion }}
+    # this variable controls the version of Piwik your tests will run against.
+    # by default it will run against the maximum support version read from plugin.json
+    # (PIWIK_TEST_TARGET=maximum_supported_piwik).
+    # You can also specify a specific Piwik version
+    # (PIWIK_TEST_TARGET=2.16.0-b1).
+    - PIWIK_TEST_TARGET=maximum_supported_piwik
 {% endif %}
 {% if extraGlobalEnvVars|default is not empty %}{% for var in extraGlobalEnvVars %}    - {{ var|raw }}
 {% endfor %}{% endif %}

--- a/get_required_piwik_version.php
+++ b/get_required_piwik_version.php
@@ -26,7 +26,7 @@ if ($returnMaxVersion) {
     $versionToReturn = getMaxVersion($requiredVersions);
 
     if (empty($versionToReturn)) {
-        $versionToReturn = trim(file_get_contents('http://builds.piwik.org/LATEST_BETA'));
+        $versionToReturn = trim(file_get_contents('http://api.piwik.org/LATEST_BETA'));
     }
 } else {
     $versionToReturn = getMinVersion($requiredVersions);

--- a/get_required_piwik_version.php
+++ b/get_required_piwik_version.php
@@ -6,32 +6,34 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
+$pluginName = $argv[1];
+$returnMaxVersion = !empty($argv[2]) && $argv[2] === 'max';
+
 // tiny script to get plugin version from plugin.json from a bash script
 require_once __DIR__ . '/../../core/Version.php';
-
-$pluginName = $argv[1];
+require_once __DIR__ . '/piwik_version_parser.php';
 
 // at this point in travis the plugin to test against is not in the piwik directory. we could move it to piwik
 // beforehand, but for plugins that are also stored as submodules, this would erase the plugin or fail when git
 // submodule update is called
-$pluginJsonPath = __DIR__ . "/../../../$pluginName/plugin.json";
-
+$pluginJsonPath     = __DIR__ . "/../../../$pluginName/plugin.json";
 $pluginJsonContents = file_get_contents($pluginJsonPath);
 $pluginJsonContents = json_decode($pluginJsonContents, true);
 
-$minimumRequiredPiwik = @$pluginJsonContents["require"]["piwik"];
+$requiredVersions = getRequiredPiwikVersions($pluginJsonContents);
 
-if (empty($minimumRequiredPiwik)) {
-    $minimumRequiredPiwik = "master";
-} else {
-    if (!preg_match("/^[^0-9]*(.*)/", $minimumRequiredPiwik, $matches)
-        || empty($matches[1])
-        || version_compare($matches[1], \Piwik\Version::VERSION) > 0
-    ) {
-        $minimumRequiredPiwik = "master";
-    } else {
-        $minimumRequiredPiwik = $matches[1];
+if ($returnMaxVersion) {
+    $versionToReturn = getMaxVersion($requiredVersions);
+
+    if (empty($versionToReturn)) {
+        $versionToReturn = trim(file_get_contents('http://builds.piwik.org/LATEST_BETA'));
     }
+} else {
+    $versionToReturn = getMinVersion($requiredVersions);
 }
 
-echo $minimumRequiredPiwik;
+if (empty($versionToReturn)) {
+    $versionToReturn = "master";
+}
+
+echo $versionToReturn;

--- a/piwik_version_parser.php
+++ b/piwik_version_parser.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+// tiny script to get plugin version from plugin.json from a bash script
+require_once __DIR__ . '/../../core/Version.php';
+
+function getRequiredPiwikVersions($pluginJsonContents)
+{
+    $requiredPiwikVersion = '';
+    if (isset($pluginJsonContents["require"]["piwik"])) {
+        $requiredPiwikVersion = (string) $pluginJsonContents["require"]["piwik"];
+    }
+
+    $requiredVersions = explode(',', $requiredPiwikVersion);
+
+    $versions = array();
+    foreach ($requiredVersions as $required) {
+        if (preg_match('{^(<>|!=|>=?|<=?|==?)\s*(.*)}', $required, $matches)) {
+            $comparison = trim($matches[1]);
+            $version = $matches[2];
+
+            if (!preg_match("/^[^0-9]*(.*)/", $version)
+                || empty($version)
+                || version_compare($version, \Piwik\Version::VERSION) > 0) {
+                // not a valid version number
+                continue;
+            }
+
+            $versions[] = array(
+                'comparison' => $comparison,
+                'version' => $version
+            );
+        }
+    }
+
+    return $versions;
+}
+
+function getMinVersion(array $requiredVersions)
+{
+    $minVersion = '';
+
+    foreach ($requiredVersions as $required) {
+        $comparison = $required['comparison'];
+        $version    = $required['version'];
+
+        if (in_array($comparison, array('>=','>', '=='))) {
+            if (empty($minVersion)) {
+                $minVersion = $version;
+            } elseif (version_compare($version, $minVersion, '<=')) {
+                $minVersion = $version;
+            }
+        }
+    }
+
+    return $minVersion;
+}
+
+function getMaxVersion(array $requiredVersions)
+{
+    $maxVersion = '';
+
+    foreach ($requiredVersions as $required) {
+        $comparison = $required['comparison'];
+        $version    = $required['version'];
+
+        if (in_array($comparison, array('<', '<=', '=='))) {
+            if (empty($maxVersion)) {
+                $maxVersion = $version;
+            } elseif (version_compare($version, $maxVersion, '>=')) {
+                $maxVersion = $version;
+            }
+        }
+    }
+
+    return $maxVersion;
+}


### PR DESCRIPTION
refs piwik/piwik#8695 

Tested it here 
* With no max Piwik version specified in plugin.json automatically runs against latest beta  (` "piwik": ">=2.15.0-rc1`) https://travis-ci.org/piwik/plugin-AnonymousPiwikUsageMeasurement/jobs/101955204
* With max Piwik version specified in plugin.json runs against configured max version (` "piwik": ">=2.15.0-rc1,<=2.15.1-b11"`) In this case max supported version is 2.15.1-b11 https://travis-ci.org/piwik/plugin-AnonymousPiwikUsageMeasurement/builds/101955789

Made it in a way that it should be backwards compatible and in a way that it is still possible to specify a specific Piwik target version instead of automatically using the maximum supported Piwik version from plugin.json.

Also see comment in https://github.com/piwik/piwik/issues/8695#issuecomment-171075224