### PR TITLE
Disable tls for composer on php 5.3

### DIFF
--- a/generator/templates/travis.yml.twig
+++ b/generator/templates/travis.yml.twig
@@ -135,6 +135,9 @@ install:
 
   - ./tests/travis/configure_git.sh
 
+  # disable tls for php 5.3 as openssl isn't available
+  - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && composer config -g -- disable-tls true || true'
+
   # travis now complains about this failing 9 times out of 10, so removing it
   #- travis_retry composer self-update
 


### PR DESCRIPTION
OpenSSL isn't available on PHP 5.3.3 on travis ci

Tested this on ReferrersManager plugin: https://travis-ci.org/sgiehl/piwik-plugin-ReferrersManager/builds/123747284

fixes #23