### PR TITLE
Plugins builds artifacts will now upload publicly by default, unless PROTECTED_ARTIFACTS=1 is set in travis.yml

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -43,7 +43,7 @@ then
         then
             echo -n " --repository=piwik/plugin-$PLUGIN_NAME"
 
-            if [ "$UNPROTECTED_ARTIFACTS" = "" ];
+            if [ "$PROTECTED_ARTIFACTS" = "1" ];
             then
                 echo -n " --http-user=... --http-password=..."
             fi

--- a/upload_artifacts.sh
+++ b/upload_artifacts.sh
@@ -18,7 +18,7 @@ else
 
         if [ -n "$PLUGIN_NAME" ];
         then
-            if [ "$UNPROTECTED_ARTIFACTS" = "" ];
+            if [ "$PROTECTED_ARTIFACTS" = "1" ];
             then
                 echo "Artifacts will be protected (premium plugin)..."
                 url_base="$url_base&protected=1"


### PR DESCRIPTION
refs https://github.com/piwik/piwik/issues/10323

follows up
https://github.com/piwik/piwik/issues/6938
https://github.com/piwik/piwik/issues/7761
https://github.com/piwik/ui-tests-viewer/pull/22