### PR TITLE
properly keeps non-zero exit codes for "AllTests"

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -68,21 +68,25 @@ then
         fi
     elif [ "$TEST_SUITE" = "AllTests" ]
     then
+        exit_code=0
+
         if [ "$ALLTEST_EXTRA_OPTIONS" = "--run-first-half-only" ]
         then
             echo "Executing tests in test suite SystemTests"
-            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite SystemTests --colors $PHPUNIT_EXTRA_OPTIONS
+            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite SystemTests --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
             echo "Executing tests in test suite UnitTests"
-            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite UnitTests --colors $PHPUNIT_EXTRA_OPTIONS
+            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite UnitTests --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
         elif [ "$ALLTEST_EXTRA_OPTIONS" = "--run-second-half-only" ]
         then
             echo "Executing tests in test suite IntegrationTests"
-            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite IntegrationTests --colors $PHPUNIT_EXTRA_OPTIONS
+            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite IntegrationTests --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
             echo "Executing tests in test suite PluginTests"
-            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite PluginTests --colors $PHPUNIT_EXTRA_OPTIONS
+            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite PluginTests --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
         else
-            travis_wait ./../../console tests:run --options="--colors"
+            travis_wait ./../../console tests:run --options="--colors" || exit_code=$?
         fi
+
+        exit $exit_code
     else
         if [ -n "$PLUGIN_NAME" ]
         then


### PR DESCRIPTION
As mentioned in piwik/piwik#11695 there are some parts of the test suites reporting success while actually failing.

The problem was that with the "AllTests" partioning dropped the first exit code returned from phpunit. This patch returns the "last non-zero exit code" if any occurs.

To demonstrate the patch I set up two travis runs:
- https://travis-ci.org/mneudert/piwik/builds/246552251 (branched of the merge commit referencing the original issue)
- https://travis-ci.org/mneudert/piwik/builds/246603570 (updated submodule to use updates `travis.sh`)

(the unrelated mysqli issues seem to already be known...)