### PR TITLE
Allow plugins to easily use the Travis trusty distribution

### DIFF
--- a/generator/GenerateTravisYmlFile.php
+++ b/generator/GenerateTravisYmlFile.php
@@ -46,7 +46,7 @@ class GenerateTravisYmlFile extends Command
             ->addOption('repo-root-dir', null, InputOption::VALUE_REQUIRED, "Path to the repo for whom a .travis.yml file will be generated for.")
             ->addOption('force-php-tests', null, InputOption::VALUE_NONE, "Forces the presence of the PHP tests jobs for plugin builds.")
             ->addOption('force-ui-tests', null, InputOption::VALUE_NONE, "Forces the presence of the UI tests jobs for plugin builds.")
-            ->addOption('sudo-false', null, InputOption::VALUE_NONE, "If supplied, the .travis.yml file will use travis' new infrastructure.");
+            ->addOption('sudo-false', null, InputOption::VALUE_NONE, "If supplied, the .travis.yml file will use travis' container environment.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/generator/GenerateTravisYmlFile.php
+++ b/generator/GenerateTravisYmlFile.php
@@ -46,6 +46,7 @@ class GenerateTravisYmlFile extends Command
             ->addOption('repo-root-dir', null, InputOption::VALUE_REQUIRED, "Path to the repo for whom a .travis.yml file will be generated for.")
             ->addOption('force-php-tests', null, InputOption::VALUE_NONE, "Forces the presence of the PHP tests jobs for plugin builds.")
             ->addOption('force-ui-tests', null, InputOption::VALUE_NONE, "Forces the presence of the UI tests jobs for plugin builds.")
+            ->addOption('dist-trusty', null, InputOption::VALUE_NONE, "If supplied, the .travis.yml file will use travis' trusty distribution.")
             ->addOption('sudo-false', null, InputOption::VALUE_NONE, "If supplied, the .travis.yml file will use travis' container environment.");
     }
 

--- a/generator/Generator.php
+++ b/generator/Generator.php
@@ -147,6 +147,10 @@ abstract class Generator
 
         $this->setExtraEnvironmentVariables();
 
+        if (!empty($this->options['dist-trusty'])) {
+            $this->view->useTravisTrustyDistribution();
+        }
+
         if (!empty($this->options['sudo-false'])) {
             $this->view->useTravisContainerEnvironment();
         }

--- a/generator/Generator.php
+++ b/generator/Generator.php
@@ -148,7 +148,7 @@ abstract class Generator
         $this->setExtraEnvironmentVariables();
 
         if (!empty($this->options['sudo-false'])) {
-            $this->view->useNewTravisInfrastructure();
+            $this->view->useTravisContainerEnvironment();
         }
     }
 

--- a/generator/Generator/PluginTravisYmlGenerator.php
+++ b/generator/Generator/PluginTravisYmlGenerator.php
@@ -83,7 +83,7 @@ class PluginTravisYmlGenerator extends Generator
             $testsToRun[] = array('name' => 'PluginTests',
                 'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik");
 
-            $testsToExclude[] = array('description' => 'execute latest stable tests only w/ PHP 5.5',
+            $testsToExclude[] = array('description' => 'execute latest stable tests only w/ PHP 5.6',
                 'php' => $this->minimumPhpVersion,
                 'env' => 'TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik');
         }

--- a/generator/TravisYmlView.php
+++ b/generator/TravisYmlView.php
@@ -254,6 +254,11 @@ class TravisYmlView
         $this->variables['useTravisContainerEnvironment'] = true;
     }
 
+    public function useTravisTrustyDistribution()
+    {
+        $this->variables['useTravisTrustyDistribution'] = true;
+    }
+
     public function render()
     {
         return $this->twig->render('travis.yml.twig', $this->variables);

--- a/generator/TravisYmlView.php
+++ b/generator/TravisYmlView.php
@@ -249,9 +249,9 @@ class TravisYmlView
         $this->variables['latestStableVersion'] = $latestStableVersion;
     }
 
-    public function useNewTravisInfrastructure()
+    public function useTravisContainerEnvironment()
     {
-        $this->variables['useNewTravisInfrastructure'] = true;
+        $this->variables['useTravisContainerEnvironment'] = true;
     }
 
     public function render()

--- a/generator/templates/travis.yml.twig
+++ b/generator/templates/travis.yml.twig
@@ -43,7 +43,7 @@ addons:
 {% if partials['addons.apt.packages']|default is not empty %}      {{ partials['addons.apt.packages']|indent(6)|raw }}
 {% endif %}
 
-{% if generationMode == 'core' %}
+{% if generationMode == 'core' or useTravisTrustyDistribution|default %}
 git:
   lfs_skip_smudge: true
 

--- a/generator/templates/travis.yml.twig
+++ b/generator/templates/travis.yml.twig
@@ -95,7 +95,7 @@ dist: trusty
 {% else %}
 dist: precise
 
-sudo: {% if useNewTravisInfrastructure|default %}false{% else %}required{% endif %}
+sudo: {% if useTravisContainerEnvironment|default %}false{% else %}required{% endif %}
 
 {% endif %}
 

--- a/generator/templates/travis.yml.twig
+++ b/generator/templates/travis.yml.twig
@@ -90,10 +90,9 @@ matrix:
   {{ existingMatrix|trim|raw }}
 {% endif %}
 
-{% if generationMode == 'core' %}
-dist: trusty
-{% else %}
-dist: precise
+dist: {% if generationMode == 'core' or useTravisTrustyDistribution|default %}trusty{% else %}precise{% endif %}
+
+{% if generationMode == 'plugin' %}
 
 sudo: {% if useTravisContainerEnvironment|default %}false{% else %}required{% endif %}
 

--- a/generator/tests/Integration/TravisYmlViewTest.php
+++ b/generator/tests/Integration/TravisYmlViewTest.php
@@ -32,7 +32,7 @@ class TravisYmlViewTest extends PHPUnit_Framework_TestCase
             array('name' => "PluginTests", 'vars' => "MYSQL_ADAPTER=PDO_MYSQL"),
             array('name' => "PluginTests", 'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=latest_stable")
         ));
-        $view->useNewTravisInfrastructure();
+        $view->useTravisContainerEnvironment();
         $output = $view->render();
 
         $yaml = Spyc::YAMLLoadString($output);

--- a/generator/tests/Integration/TravisYmlViewTest.php
+++ b/generator/tests/Integration/TravisYmlViewTest.php
@@ -33,6 +33,7 @@ class TravisYmlViewTest extends PHPUnit_Framework_TestCase
             array('name' => "PluginTests", 'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=latest_stable")
         ));
         $view->useTravisContainerEnvironment();
+        $view->useTravisTrustyDistribution();
         $output = $view->render();
 
         $yaml = Spyc::YAMLLoadString($output);
@@ -49,6 +50,7 @@ class TravisYmlViewTest extends PHPUnit_Framework_TestCase
         $this->assertContains("TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=latest_stable", $yaml['env']['matrix']);
         $this->assertNotContains("TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL", $yaml['env']['matrix']);
 
+        $this->assertEquals('trusty', $yaml['dist']);
         $this->assertEquals(false, $yaml['sudo']);
 
         $this->assertBuildSectionsNotEmpty($yaml);


### PR DESCRIPTION
The fork commit obviously has to be removed for merging. It is currently only in place to ensure a test plugin can be used with the new generator option.

[refs piwik/piwik#11986]